### PR TITLE
Allow even newer versions of signxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r", encoding="utf-8") as file:
 
 setup(
     name="david-energy-openleadr",
-    version="0.5.34",
+    version="0.5.35",
     description="Python3 library for building OpenADR Clients (VENs) and Servers (VTNs)",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -38,7 +38,7 @@ setup(
         "aiohttp>=3.8.3,<4.0.0",
         "apscheduler>=3.10.0,<4.0.0",
         "jinja2>=3.1.2,<4.0.0",
-        "signxml>=3.1.0,<3.3.0",
+        "signxml>=3.1.0,<4.1",
     ],
     entry_points={
         "console_scripts": ["fingerprint = openleadr.fingerprint:show_fingerprint"]


### PR DESCRIPTION
### Description

Signxml 3.2 uses now-removed pyopenssl modules and methods (signxml.verifier uses OpenSSL.crypto in particular). Signxml 4.0 is a big change under the hood but the public API remains the same, except for use of ca_path, which we don't appear to use anywhere. By updating this, we'll then be able to update pyopenssl and cryptography.

Signxml changelog is at https://github.com/XML-Security/signxml/blob/main/Changes.rst

### Testing

Very challenging to really test. I ran openleadr locally with the new signxml and all the tests passed except for 3, which fail because "report_request_id=None" is being stripped out of the generated XML. That doesn't appear to be related to my change, since there's no signing involved in that process.

### Task and Issue Tracking

- [Asana Task](https://app.asana.com/0/1208949208553087/1208949208553092/f)